### PR TITLE
Adds paginated and grouped views (authors/languages/tags)

### DIFF
--- a/lasswitz/routes.py
+++ b/lasswitz/routes.py
@@ -1,6 +1,15 @@
 def includeme(config):
     config.add_static_view('static', 'static', cache_max_age=3600)
     config.add_route('home', '/')
+    config.add_route('autor', '/autor')
     config.add_route('blank', '/_')
     config.add_route('search', '/search')
     config.add_route('bibtex', '/bibtex')
+    config.add_route('manuscript_detail', '/manuscript/{id}')
+    config.add_route('authors', '/authors')
+    config.add_route('author_detail', '/author/{id}')
+    config.add_route('languages', '/languages')
+    config.add_route('language_detail', '/language/{code}')
+    config.add_route('tags', '/tags')
+    config.add_route('tag_detail', '/tag/{name}')
+

--- a/lasswitz/static/app.css
+++ b/lasswitz/static/app.css
@@ -1,0 +1,17 @@
+:root { --bg:#a3262a; --text:#fff; --muted:#f0dada; }
+body { margin:0; font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto; background:var(--bg); color:var(--text);}
+.topbar { display:flex; align-items:center; justify-content:space-between; padding:16px 28px; }
+.brand { font-weight:700; font-size:22px; text-decoration:none; color:#fff; letter-spacing:.3px; }
+.nav a { color:#fff; text-decoration:none; margin-left:18px; opacity:.9 }
+.nav a:hover { opacity:1; text-decoration:underline; }
+.page { max-width:980px; margin:20px auto 64px; padding:0 20px; }
+.card { background:rgba(255,255,255,.06); border-radius:14px; padding:18px 22px; margin:12px 0; }
+.muted { color:var(--muted); }
+.chips a { display:inline-block; margin:0 8px 8px 0; padding:6px 10px; border-radius:999px; background:rgba(255,255,255,.12); color:#fff; text-decoration:none; font-size:12px;}
+.chips a:hover { background:rgba(255,255,255,.18); }
+.pagination { margin-top: 16px; font-size: 0.9rem; }
+.pagination a { color: #fff; text-decoration: none; margin: 0 8px; }
+.pagination a:hover { text-decoration: underline; }
+.h1 { font-size:44px; font-weight:700; margin:8px 0 6px; }
+.h2 { font-size:18px; font-weight:600; margin:0 0 14px; }
+.lead { font-size: 18px; margin-bottom: 20px; }

--- a/lasswitz/templates/author_detail.jinja2
+++ b/lasswitz/templates/author_detail.jinja2
@@ -1,0 +1,22 @@
+{% extends "layout.jinja2" %}
+
+{% block content %}
+<h1 class="h1">{{ author.familyname }}, {{ author.givenname }}</h1>
+
+{% if manuscripts %}
+  {% for m in manuscripts %}
+    <div class="card">
+      <a href="{{ request.route_url('manuscript_detail', id=m.id) }}" class="h2">
+        {{ m.title }}
+      </a>
+      <div class="muted">
+        {% if m.language %}<strong>Idioma:</strong> {{ m.language }}{% endif %}
+      </div>
+    </div>
+  {% endfor %}
+{% else %}
+  <p>Este autor no tiene manuscritos registrados.</p>
+{% endif %}
+
+{% endblock %}
+

--- a/lasswitz/templates/authors.jinja2
+++ b/lasswitz/templates/authors.jinja2
@@ -1,0 +1,22 @@
+{% extends "layout.jinja2" %}
+
+{% block content %}
+<h1 class="h1">Autores</h1>
+
+{% if authors %}
+  {% for author in authors %}
+    <div class="card">
+      <a href="{{ request.route_url('author_detail', id=author.id) }}" class="h2">
+        {{ author.familyname }}, {{ author.givenname }}
+      </a>
+      <div class="muted">
+        {{ author.manuscripts|length }} manuscrito(s)
+      </div>
+    </div>
+  {% endfor %}
+{% else %}
+  <p>No hay autores registrados.</p>
+{% endif %}
+
+{% endblock %}
+

--- a/lasswitz/templates/language_detail.jinja2
+++ b/lasswitz/templates/language_detail.jinja2
@@ -1,0 +1,18 @@
+{% extends "layout.jinja2" %}
+
+{% block content %}
+<h1 class="h1">Idioma: {{ code }}</h1>
+
+{% if manuscripts %}
+  {% for m in manuscripts %}
+    <div class="card">
+      <a href="{{ request.route_url('manuscript_detail', id=m.id) }}" class="h2">
+        {{ m.title }}
+      </a>
+    </div>
+  {% endfor %}
+{% else %}
+  <p>No hay manuscritos en este idioma.</p>
+{% endif %}
+
+{% endblock %}

--- a/lasswitz/templates/languages.jinja2
+++ b/lasswitz/templates/languages.jinja2
@@ -1,0 +1,19 @@
+{% extends "layout.jinja2" %}
+
+{% block content %}
+<h1 class="h1">Idiomas</h1>
+
+{% for code, n in languages %}
+  {% if code %}
+    <div class="card">
+      <a href="{{ request.route_url('language_detail', code=code) }}" class="h2">
+        {{ code }}
+      </a>
+      <div class="muted">{{ n }} manuscrito(s)</div>
+    </div>
+  {% endif %}
+{% else %}
+  <p>No se encontraron idiomas.</p>
+{% endfor %}
+
+{% endblock %}

--- a/lasswitz/templates/layout.jinja2
+++ b/lasswitz/templates/layout.jinja2
@@ -16,6 +16,12 @@
     <!-- Custom styles for this scaffold -->
     <link href="{{request.static_url('lasswitz:static/theme.css')}}" rel="stylesheet">
 
+    <!-- Modern fonts and custom CSS -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ request.static_url('lasswitz:static/app.css') }}">
+
+
     <!-- HTML5 shiv and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js" integrity="sha384-0s5Pv64cNZJieYFkXYOTId2HMA2Lfb6q2nAcx2n0RTLUnCAoTTsS0nKEO27XyKcY" crossorigin="anonymous"></script>
@@ -23,42 +29,37 @@
     <![endif]-->
   </head>
 
-  <body>
-
-    <div class="starter-template">
-      <div class="container">
-        <div class="row">
-          <div class="col-md-2">
-            <img class="logo img-responsive" src="{{request.static_url('lasswitz:static/pyramid.png') }}" alt="pyramid web framework">
-          </div>
-          <div class="col-md-10">
-            {% block content %}
-                <p>No content</p>
-            {% endblock content %}
-          </div>
-        </div>
-        <div class="row">
-          <div class="links">
-            <ul>
-              <li><i class="glyphicon glyphicon-cog icon-muted"></i><a href="https://github.com/Pylons/pyramid">Github Project</a></li>
-              <li><i class="glyphicon glyphicon-globe icon-muted"></i><a href="https://webchat.freenode.net/?channels=pyramid">IRC Channel</a></li>
-              <li><i class="glyphicon glyphicon-home icon-muted"></i><a href="https://pylonsproject.org">Pylons Project</a></li>
-            </ul>
-          </div>
-        </div>
-        <div class="row">
-          <div class="copyright">
-            Copyright &copy; Pylons Project
-          </div>
-        </div>
-      </div>
-    </div>
+    <body>
 
 
-    <!-- Bootstrap core JavaScript
-    ================================================== -->
-    <!-- Placed at the end of the document so the pages load faster -->
-    <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+  <div class="topbar">
+    <a href="{{ request.route_url('home') }}" class="brand">Lasswitz</a>
+    <nav class="nav">
+      <a href="{{ request.route_url('home') }}">Inicio</a>
+      <a href="{{ request.route_url('authors') }}">Autores</a>
+      <a href="{{ request.route_url('languages') }}">Idiomas</a>
+      <a href="{{ request.route_url('tags') }}">Etiquetas</a>
+      <a href="{{ request.route_url('bibtex') }}">Importar BibTeX</a>
+      <a href="{{ request.route_url('blank') }}">Nuevo</a>
+    </nav>
+  </div>
+
+
+
+
+  <div class="page">
+    {% block content %}{% endblock %}
+  </div>
+
+  <!-- Bootstrap core JavaScript -->
+  <!-- Placed at the end of the document so the pages load faster -->
+  <script src="//code.jquery.com/jquery-1.12.4.min.js"
+          integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
+          crossorigin="anonymous"></script>
+  <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
+          integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7L2mCWNlPG9mGCDBwGNlcpDTXxa"
+          crossorigin="anonymous"></script>
+
   </body>
-</html>
+  </html>

--- a/lasswitz/templates/manuscript_detail.jinja2
+++ b/lasswitz/templates/manuscript_detail.jinja2
@@ -1,0 +1,54 @@
+{% extends "layout.jinja2" %}
+
+{% block content %}
+<div class="content">
+
+  <h1>
+    {# Si el título trae HTML (<i>...</i>) lo renderizamos #}
+    {% if manuscript.title %}
+      {{ manuscript.title | safe }}
+    {% else %}
+      (Sin título)
+    {% endif %}
+  </h1>
+
+  {# AUTORES (clickeables) #}
+  {% if authors and authors|length > 0 %}
+    <p>
+      <strong>Autor(es):</strong>
+      {% for a in authors %}
+        <a href="{{ request.route_url('author_detail', id=a.id) }}">
+          {{ (a.familyname ~ ', ' ~ a.givenname) if (a.familyname or a.givenname) else (a.displayname or 'Autor') }}
+        </a>{% if not loop.last %}, {% endif %}
+      {% endfor %}
+    </p>
+  {% else %}
+    <p><strong>Autor(es):</strong> N/D</p>
+  {% endif %}
+
+  {# ABSTRACT #}
+  {% if manuscript.abstract %}
+    <div style="margin-top: 12px; max-width: 980px;">
+      <p style="white-space: pre-line;">
+        {{ manuscript.abstract | safe }}
+      </p>
+    </div>
+  {% endif %}
+
+  {# BODY #}
+  {% if manuscript.body %}
+    <div style="margin-top: 16px; max-width: 980px; white-space: pre-line;">
+      {{ manuscript.body | safe }}
+    </div>
+  {% endif %}
+
+  <p style="margin-top: 18px;"><strong>Idioma:</strong> {{ manuscript.language if manuscript.language else 'N/D' }}</p>
+  <p><strong>Etiquetas:</strong> {{ manuscript.tag if manuscript.tag else 'N/D' }}</p>
+
+  <p style="margin-top: 16px;">
+    <a href="{{ request.route_url('home') }}">&larr; Volver al listado</a>
+  </p>
+
+</div>
+{% endblock content %}
+

--- a/lasswitz/templates/mytemplate.jinja2
+++ b/lasswitz/templates/mytemplate.jinja2
@@ -1,8 +1,52 @@
 {% extends "layout.jinja2" %}
 
 {% block content %}
-<div class="content">
-  <h1><span class="font-semi-bold">Pyramid</span> <span class="smaller">Starter project</span></h1>
-  <p class="lead">Welcome to <span class="font-normal">{{project}}</span>, a&nbsp;Pyramid application generated&nbsp;by<br><span class="font-normal">Cookiecutter</span>.</p>
-</div>
+
+<h1 class="h1">
+    Lasswitz <span class="muted">Open Access Platform</span>
+</h1>
+
+<p class="lead">
+    Explora manuscritos académicos y herramientas de edición colaborativa.
+</p>
+
+
+
+{% if manuscripts %}
+    {% for m in manuscripts %}
+        <div class="card">
+            <a href="{{ request.route_url('manuscript_detail', id=m.id) }}" class="h2">
+                {{ m.title }}
+            </a>
+
+            <div class="muted">
+                {% if m.language %}<strong>Idioma:</strong> {{ m.language }} ·{% endif %}
+                {% if m.tag %}<strong> Etiquetas:</strong> {{ m.tag }}{% endif %}
+            </div>
+        </div>
+    {% endfor %}
+{% else %}
+    <p>No hay manuscritos registrados todavía.</p>
+{% endif %}
+
+
+{% if total_pages > 1 %}
+    <div class="pagination">
+        {% if page > 1 %}
+            <a href="{{ request.current_route_url(_query={'page': page-1}) }}">← Anterior</a>
+        {% endif %}
+
+        <span class="muted">
+            Página {{ page }} de {{ total_pages }} · {{ total }} manuscritos
+        </span>
+
+        {% if page < total_pages %}
+            <a href="{{ request.current_route_url(_query={'page': page+1}) }}">Siguiente →</a>
+        {% endif %}
+    </div>
+{% endif %}
+
+
+
 {% endblock content %}
+

--- a/lasswitz/templates/tag_detail.jinja2
+++ b/lasswitz/templates/tag_detail.jinja2
@@ -1,0 +1,18 @@
+{% extends "layout.jinja2" %}
+
+{% block content %}
+<h1 class="h1">Etiqueta: {{ name }}</h1>
+
+{% if manuscripts %}
+  {% for m in manuscripts %}
+    <div class="card">
+      <a href="{{ request.route_url('manuscript_detail', id=m.id) }}" class="h2">
+        {{ m.title }}
+      </a>
+    </div>
+  {% endfor %}
+{% else %}
+  <p>No se encontraron manuscritos con esta etiqueta.</p>
+{% endif %}
+
+{% endblock %}

--- a/lasswitz/templates/tags.jinja2
+++ b/lasswitz/templates/tags.jinja2
@@ -1,0 +1,16 @@
+{% extends "layout.jinja2" %}
+
+{% block content %}
+<h1 class="h1">Etiquetas</h1>
+
+<div class="chips">
+  {% for name, n in tags %}
+    <a href="{{ request.route_url('tag_detail', name=name) }}">
+      {{ name }} ({{ n }})
+    </a>
+  {% else %}
+    <p>No se encontraron etiquetas.</p>
+  {% endfor %}
+</div>
+
+{% endblock %}

--- a/lasswitz/views/default.py
+++ b/lasswitz/views/default.py
@@ -1,6 +1,10 @@
 from pyramid.view import view_config
 from pyramid.response import Response
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy import func
+import uuid
+from collections import Counter
+from pyramid.httpexceptions import HTTPNotFound
 
 from .. import models
 
@@ -8,11 +12,179 @@ from .. import models
 @view_config(route_name='home', renderer='lasswitz:templates/mytemplate.jinja2')
 def my_view(request):
     try:
-        query = request.dbsession.query(models.MyModel)
-        one = query.filter(models.MyModel.name == 'one').one()
+        # 1) página actual (query param ?page=)
+        try:
+            page = int(request.params.get('page', '1'))
+        except ValueError:
+            page = 1
+        page = max(page, 1)
+
+        # 2) tamaño de página (cuántos manuscritos por página)
+        per_page = 20  # puedes cambiar a 10, 25, etc.
+
+        # 3) query base
+        q = request.dbsession.query(models.Manuscript).order_by(models.Manuscript.title.asc())
+
+        # 4) total y páginas
+        total = q.count()
+        manuscripts = (
+            q.limit(per_page)
+             .offset((page - 1) * per_page)
+             .all()
+        )
+        total_pages = (total + per_page - 1) // per_page
+
     except SQLAlchemyError:
         return Response(db_err_msg, content_type='text/plain', status=500)
-    return {'one': one, 'project': 'Lasswitz'}
+
+    return {
+        'manuscripts': manuscripts,
+        'project': 'Lasswitz',
+        'page': page,
+        'total_pages': total_pages,
+        'per_page': per_page,
+        'total': total,
+    }
+
+
+
+@view_config(route_name='manuscript_detail',
+             renderer='lasswitz:templates/manuscript_detail.jinja2')
+def manuscript_detail(request):
+    mid = request.matchdict.get('id')
+    # Convertir el id de la URL a UUID; si no es válido, 404
+    try:
+        mid_uuid = uuid.UUID(mid)
+    except (TypeError, ValueError):
+        raise HTTPNotFound()
+
+    # Buscar el manuscrito con esa PK
+    manuscript = request.dbsession.query(models.Manuscript).get(mid_uuid)
+    if manuscript is None:
+        raise HTTPNotFound()
+    authors = list(manuscript.creators) if manuscript.creators else []
+
+    return {
+        'manuscript': manuscript,
+        'authors': authors,
+        'project': 'Lasswitz'
+    }
+
+
+
+@view_config(route_name='authors', renderer='lasswitz:templates/authors.jinja2')
+def authors_view(request):
+    session = request.dbsession
+
+    # Autores que tengan al menos un manuscrito
+    authors = (
+        session.query(models.AcademicPerson)
+        .join(models.AcademicPerson.manuscripts)   # usa la relación many-to-many
+        .distinct()
+        .order_by(models.AcademicPerson.familyname.asc(),
+                  models.AcademicPerson.givenname.asc())
+        .all()
+    )
+
+    return {
+        'authors': authors,
+        'project': 'Lasswitz',
+    }
+
+
+
+@view_config(route_name='author_detail', renderer='lasswitz:templates/author_detail.jinja2')
+def author_detail(request):
+    session = request.dbsession
+    try:
+        aid = uuid.UUID(request.matchdict.get('id'))
+    except (TypeError, ValueError):
+        raise HTTPNotFound()
+
+    author = session.query(models.AcademicPerson).get(aid)
+    if author is None:
+        raise HTTPNotFound()
+
+    manuscripts = (
+        session.query(models.Manuscript)
+        .join(models.Manuscript.creators)
+        .filter(models.AcademicPerson.id == aid)
+        .order_by(models.Manuscript.title.asc())
+        .all()
+    )
+
+    return {'author': author, 'manuscripts': manuscripts, 'project': 'Lasswitz'}
+
+
+@view_config(route_name='languages', renderer='lasswitz:templates/languages.jinja2')
+def languages_view(request):
+    session = request.dbsession
+    rows = (
+        session.query(
+            models.Manuscript.language,
+            func.count(models.Manuscript.id)
+        )
+        .group_by(models.Manuscript.language)
+        .order_by(models.Manuscript.language.asc())
+        .all()
+    )
+    # rows es lista de (codigo, cantidad)
+    return {'languages': rows, 'project': 'Lasswitz'}
+
+
+@view_config(route_name='language_detail', renderer='lasswitz:templates/language_detail.jinja2')
+def language_detail(request):
+    code = request.matchdict.get('code')
+    if not code:
+        raise HTTPNotFound()
+
+    session = request.dbsession
+    manuscripts = (
+        session.query(models.Manuscript)
+        .filter(models.Manuscript.language == code)
+        .order_by(models.Manuscript.title.asc())
+        .all()
+    )
+
+    return {'code': code, 'manuscripts': manuscripts, 'project': 'Lasswitz'}
+
+
+@view_config(route_name='tags', renderer='lasswitz:templates/tags.jinja2')
+def tags_view(request):
+    session = request.dbsession
+    all_ms = session.query(models.Manuscript).all()
+
+    counter = Counter()
+    for m in all_ms:
+        raw = (m.tag or m.keywords or '') or ''
+        for t in [x.strip() for x in raw.split(',') if x.strip()]:
+            counter[t] += 1
+
+    tags = sorted(counter.items(), key=lambda x: (-x[1], x[0].lower()))
+    return {'tags': tags, 'project': 'Lasswitz'}
+
+
+@view_config(route_name='tag_detail', renderer='lasswitz:templates/tag_detail.jinja2')
+def tag_detail(request):
+    name = request.matchdict.get('name')
+    if not name:
+        raise HTTPNotFound()
+
+    session = request.dbsession
+    like = f'%{name}%'
+    manuscripts = (
+        session.query(models.Manuscript)
+        .filter(
+            (models.Manuscript.tag.ilike(like)) |
+            (models.Manuscript.keywords.ilike(like))
+        )
+        .order_by(models.Manuscript.title.asc())
+        .all()
+    )
+
+    return {'name': name, 'manuscripts': manuscripts, 'project': 'Lasswitz'}
+
+
 
 
 db_err_msg = """\

--- a/lasswitz/views/manubot.py
+++ b/lasswitz/views/manubot.py
@@ -14,7 +14,7 @@ from pyramid.renderers import render_to_response
 @view_config(route_name='search', renderer='lasswitz:templates/search_template.jinja2')
 def search_view(request):
     try:
-        engine = create_engine('sqlite:////Users/uriel/Documents/lasswitz/zotero.sqlite')
+        engine = create_engine('sqlite:///zotero.sqlite')
 
         # Crear un objeto MetaData
         metadata = MetaData()

--- a/populate_authors.py
+++ b/populate_authors.py
@@ -1,0 +1,89 @@
+import uuid
+from sqlalchemy import create_engine, text
+
+def main():
+    # 1) Cargar el entorno Pyramid y obtener dbsession
+    # Ejecuta esto con: env/bin/python populate_authors.py development.ini
+    import sys
+    if len(sys.argv) < 2:
+        print("Uso: env/bin/python populate_authors.py development.ini")
+        return
+
+    config_uri = sys.argv[1]
+
+    from pyramid.paster import bootstrap
+    env = bootstrap(config_uri)
+    request = env["request"]
+
+    from lasswitz import models
+
+    # 2) Cambia esta ruta a tu zotero.sqlite
+    zotero_path = "sqlite:////home/omarrbt/lasswitz/zotero55.sqbpro"
+    engine = create_engine(zotero_path)
+    conn = engine.connect()
+
+    consulta_sql = text("""
+        SELECT items.itemID,
+               creators.firstName AS NOMBRE,
+               creators.lastName AS APELLIDO
+        FROM items
+        JOIN itemCreators ON items.itemID = itemCreators.itemID
+        JOIN creators ON itemCreators.creatorID = creators.creatorID
+        WHERE items.itemTypeID IN (7, 8, 22)
+    """)
+
+    result = conn.execute(consulta_sql)
+
+    session = request.dbsession
+    n_links = 0
+    n_authors_new = 0
+    n_missing_manuscript = 0
+
+    for row in result:
+        zotid = int(row[0])
+        given = (row[1] or "").strip()
+        family = (row[2] or "").strip()
+
+        # Buscar manuscrito existente por zotid
+        m = session.query(models.Manuscript).filter_by(zotid=zotid).first()
+        if m is None:
+            n_missing_manuscript += 1
+            continue
+
+        # Buscar/crear autor
+        author = (
+            session.query(models.AcademicPerson)
+            .filter_by(givenname=given, familyname=family)
+            .first()
+        )
+
+        if author is None:
+            author = models.AcademicPerson(
+                id=uuid.uuid4(),
+                username=(f"{given}.{family}".lower().replace(" ", "_")[:100] or str(uuid.uuid4())[:12]),
+                displayname=(f"{given} {family}".strip() or "Autor"),
+                givenname=given,
+                familyname=family,
+            )
+            session.add(author)
+            n_authors_new += 1
+
+        # Crear vínculo si falta
+        if author not in m.creators:
+            m.creators.append(author)
+            n_links += 1
+
+    conn.close()
+
+    # 3) Commit
+    import transaction
+    transaction.commit()
+
+    print("✅ Autores nuevos creados:", n_authors_new)
+    print("✅ Vínculos autor-manuscrito creados:", n_links)
+    print("ℹ️ Manuscritos no encontrados por zotid:", n_missing_manuscript)
+
+    env["closer"]()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a major expansion of the Lasswitz platform, adding support for browsing and viewing manuscripts by author, language, and tag. It also includes a significant visual redesign with a new layout and custom CSS, as well as pagination for the manuscript list and a new script for populating author data from Zotero. The changes improve both the frontend user experience and backend querying capabilities.

**Key changes:**

**1. New Browsing Features and Views**
- Added views, templates, and routes to browse manuscripts by author, language, and tag, including detail pages for each [[1]](diffhunk://#diff-0f40e723af2f2c24225d944fcfb61e7afb71477b4a9a0b771330296230f042eaR4-R15) [[2]](diffhunk://#diff-c7da78cc78cbc33587aadf784f553c5c90525e1a8f43c37fd1fb9fc77843b750R4-R187) [[3]](diffhunk://#diff-7f7884ce1ad91d9841aeb3c42c78c67d6421fef24df49911c44fd3f90c64411eR1-R22) [[4]](diffhunk://#diff-644aa333519e28b6266a7cba68a517dbbed1b3ad003627ba176aae1071474558R1-R22) [[5]](diffhunk://#diff-ca9dfe1fd7960481a316e11e13503a556eff9a594bf57ec118bebb0094e5dea8R1-R19) [[6]](diffhunk://#diff-8017bee9b483318311efd76dfe1f9fcb1a692787c0b9eaa94c738c3339e82c59R1-R18) [[7]](diffhunk://#diff-e0ed2d0bc8e2cb950b0d488301cb6d02be80010d1955996ca3662a9e9bdb26beR1-R16) [[8]](diffhunk://#diff-4b046ddf656d648cacae89dd440f65b9f55197a05b8303c87e1e93ebf7fbbdfcR1-R18).
- Implemented backend logic to support these new routes, including database queries for listing and filtering manuscripts and authors.

**2. Manuscript List Pagination**
- Replaced the basic home view with a paginated manuscript list, making it easier to navigate large numbers of manuscripts [[1]](diffhunk://#diff-c7da78cc78cbc33587aadf784f553c5c90525e1a8f43c37fd1fb9fc77843b750R4-R187) [[2]](diffhunk://#diff-1fbb870bff1dc949e47eaf689a3a7533cbc1d7f5858e5150f0a62420df03d201L4-R52).

**3. Visual Redesign and Layout Improvements**
- Introduced a new layout with a top navigation bar, modern fonts, and custom CSS for a cleaner, more user-friendly interface [[1]](diffhunk://#diff-a30dc8bb33369844e2f23daade8a82060d350d023b27fecfcd9b9789af4b2907R19-R24) [[2]](diffhunk://#diff-a30dc8bb33369844e2f23daade8a82060d350d023b27fecfcd9b9789af4b2907L28-R63) [[3]](diffhunk://#diff-cee1d1cb709f21e4c766d85485504a0f3fc576a0ba28a2feee0559d7d4a3a163R1-R17).
- Updated all templates to use the new layout and styling [[1]](diffhunk://#diff-1fbb870bff1dc949e47eaf689a3a7533cbc1d7f5858e5150f0a62420df03d201L4-R52) [[2]](diffhunk://#diff-7f7884ce1ad91d9841aeb3c42c78c67d6421fef24df49911c44fd3f90c64411eR1-R22) [[3]](diffhunk://#diff-644aa333519e28b6266a7cba68a517dbbed1b3ad003627ba176aae1071474558R1-R22) [[4]](diffhunk://#diff-ca9dfe1fd7960481a316e11e13503a556eff9a594bf57ec118bebb0094e5dea8R1-R19) [[5]](diffhunk://#diff-8017bee9b483318311efd76dfe1f9fcb1a692787c0b9eaa94c738c3339e82c59R1-R18) [[6]](diffhunk://#diff-e0ed2d0bc8e2cb950b0d488301cb6d02be80010d1955996ca3662a9e9bdb26beR1-R16) [[7]](diffhunk://#diff-4b046ddf656d648cacae89dd440f65b9f55197a05b8303c87e1e93ebf7fbbdfcR1-R18) [[8]](diffhunk://#diff-ff37291025743d7bcf1ce5853b486a15c231ce5fb0a1c3d3a7bfd4c59eec74e5R1-R54).

**4. Data Import/Utility Script**
- Added `populate_authors.py`, a script to import authors from a Zotero database and link them to manuscripts, facilitating bulk data population.

**5. Miscellaneous Improvements**
- Updated the database connection path in the search view to use a relative path.

These updates collectively provide a much richer and more navigable platform for users to explore manuscripts, authors, languages, and tags, while also improving maintainability and extensibility for future development.